### PR TITLE
Tartarus fire/damage handling adv

### DIFF
--- a/objects/obj_player.object.gmx
+++ b/objects/obj_player.object.gmx
@@ -404,7 +404,11 @@ if (throw_ok &amp;&amp; action_pressed)
     item_id = 0;
 }
 
-
+if(inv&lt;1)//this will allow movement through enemies during damage frames
+if(instance_exists(obj_enemy_blep))//make sure the enemy exists
+if(place_meeting(x, y, obj_enemy_blep)){//checks if the enemy meets the player
+hp--;//subtracts health away from player and triggers damage handling
+}
 
 /*
 
@@ -413,7 +417,9 @@ End Of Every Step Handlers
     • Respawning
 • Death
     • Reset Variables
-
+• Enemy Damage Handing
+    • Assuming the character moves into an enemy, knockback will be applied accordingly
+    
 */
 
 //Check if out of bounds, and cause damage to the player for death
@@ -427,25 +433,28 @@ if((self.x&lt;-200)||(self.x&gt;room_width+200)||(self.y&gt;room_height+200)){
 
 //checks for death
 if(hp&lt;1){
-    //sets speeds back to zero to prevent conflicts with spawn setup
-    hsp=0;vsp=1;
-    //sets the actual position back to start
-    x=spawn[0];y=spawn[1];
-    //1/3rd of a second at 60fps, of damage invulnerability
-    inv=inv_frames;
-    //resets health to prevent this death hadnler from running again
-    hp=max_hp;
-    //invincibility frame correcting
-    last_hp=hp;
+    hsp=0;vsp=1; //sets speeds back to zero to prevent conflicts with spawn setup
+    x=spawn[0];y=spawn[1];//sets the actual position back to start
+    inv=inv_frames;//1/3rd of a second at 60fps, of damage invulnerability
+    hp=max_hp;//resets health to prevent this death hadnler from running again
+    last_hp=hp;//invincibility frame correcting
 }
 
 if(hp!=last_hp){//damage frames handler
-    if(inv==0){
+    if(inv&lt;1){//makes sure the player is not still invincible
     //even if this is called after death reset, it will be equivalent
     inv=inv_frames;
     //reset health for more damage checking
     last_hp=hp;
-    }else hp = last_hp;
+    }else hp = last_hp;//if invincible, reset health to prior
+    /*
+    Added/Optional Knockback Handler
+        • Reversed Movements attempt to handle situations where the character may become stuck
+    */
+    //makes sure the recoil is 8, horizontally
+    if((abs(hsp)&lt;8)||(abs(hsp)&gt;8))
+    hsp=8*-sign(move);
+    vsp=-vsp;//-1 = 100% knockback -- -2 = 200% knockback
 }
 
 //Setting Damage Sprites, clickering every 6th frame FOR 3 FRAMES
@@ -456,6 +465,7 @@ if(inv&gt;0&amp;&amp;inv%6&lt;3){
 }
 //removes invincibility frames until none exist
 if(inv&gt;0)inv--;
+
 
 </string>
           </argument>

--- a/objects/obj_player.object.gmx
+++ b/objects/obj_player.object.gmx
@@ -404,10 +404,13 @@ if (throw_ok &amp;&amp; action_pressed)
     item_id = 0;
 }
 
-if(inv&lt;1)//this will allow movement through enemies during damage frames
-if(instance_exists(obj_enemy_blep))//make sure the enemy exists
-if(place_meeting(x, y, obj_enemy_blep)){//checks if the enemy meets the player
+if(inv&lt;1){//this will allow movement through enemies during damage frames
+//TODO ADD ENEMIES HERE
+/*
+if(instance_exists(obj_blep))//make sure the enemy exists
+if(place_meeting(x, y, obj_blep))//checks if the enemy meets the player
 hp--;//subtracts health away from player and triggers damage handling
+*/
 }
 
 /*
@@ -462,6 +465,7 @@ if(inv&gt;0&amp;&amp;inv%6&lt;3){
     if(image_alpha&lt;1)
     image_alpha=1;
     else image_alpha=.2;
+    if(inv-1&lt;1)image_alpha=1;//make sure the sprite is not stuck at .3/1 opacity
 }
 //removes invincibility frames until none exist
 if(inv&gt;0)inv--;

--- a/objects/obj_player.object.gmx
+++ b/objects/obj_player.object.gmx
@@ -69,6 +69,7 @@ spawn[0] = x;spawn[1] = y;//default spawn information
 max_hp=10;//max allottment of health, e.g level up health
 hp = 10;// character health
 last_hp=hp;//health to determine damage
+last_dir=1;//last direction facing -- default is right
 </string>
           </argument>
         </arguments>
@@ -406,11 +407,11 @@ if (throw_ok &amp;&amp; action_pressed)
 
 if(inv&lt;1){//this will allow movement through enemies during damage frames
 //TODO ADD ENEMIES HERE
-/*
+//*
 if(instance_exists(obj_blep))//make sure the enemy exists
 if(place_meeting(x, y, obj_blep))//checks if the enemy meets the player
 hp--;//subtracts health away from player and triggers damage handling
-*/
+//*/
 }
 
 /*
@@ -424,6 +425,8 @@ End Of Every Step Handlers
     • Assuming the character moves into an enemy, knockback will be applied accordingly
     
 */
+
+if(move!=0)last_dir=move;
 
 //Check if out of bounds, and cause damage to the player for death
 //added some numbers for more leniency with auto killing
@@ -455,8 +458,16 @@ if(hp!=last_hp){//damage frames handler
         • Reversed Movements attempt to handle situations where the character may become stuck
     */
     //makes sure the recoil is 8, horizontally
-    if((abs(hsp)&lt;8)||(abs(hsp)&gt;8))
-    hsp=8*-sign(move);
+    if(hsp==0){
+        hsp=-last_dir*8;
+    }else{
+        if((abs(hsp)&lt;8)||(abs(hsp)&gt;8))
+        hsp=8*-sign(move);
+    }
+    
+    if(hsp!=0)
+    last_dir=sign(hsp);
+    
     vsp=-vsp;//-1 = 100% knockback -- -2 = 200% knockback
 }
 

--- a/objects/obj_player.object.gmx
+++ b/objects/obj_player.object.gmx
@@ -407,11 +407,11 @@ if (throw_ok &amp;&amp; action_pressed)
 
 if(inv&lt;1){//this will allow movement through enemies during damage frames
 //TODO ADD ENEMIES HERE
-//*
+/*
 if(instance_exists(obj_blep))//make sure the enemy exists
 if(place_meeting(x, y, obj_blep))//checks if the enemy meets the player
 hp--;//subtracts health away from player and triggers damage handling
-//*/
+/*/
 }
 
 /*
@@ -426,6 +426,7 @@ End Of Every Step Handlers
     
 */
 
+//sets the direction facing to the current direction if moving or changing direction
 if(move!=0)last_dir=move;
 
 //Check if out of bounds, and cause damage to the player for death
@@ -460,13 +461,18 @@ if(hp!=last_hp){//damage frames handler
     //makes sure the recoil is 8, horizontally
     if(hsp==0){
         hsp=-last_dir*8;
-    }else{
+    }else{//if this is not 0, then make sure the recoil is = (+8 || -8)
         if((abs(hsp)&lt;8)||(abs(hsp)&gt;8))
         hsp=8*-sign(move);
     }
     
+    //OPTIONAL -- Currently on
+    //sets the last direction moved the the direction of the damage
+    /*this may cause infinte bounce loops, but it preents the player
+    from getting bumped all the way to start, assuming tanking though
+    a line of enmies*/
     if(hsp!=0)
-    last_dir=sign(hsp);
+    last_dir=sign(hsp);//sign is the direction of damage
     
     vsp=-vsp;//-1 = 100% knockback -- -2 = 200% knockback
 }
@@ -474,8 +480,8 @@ if(hp!=last_hp){//damage frames handler
 //Setting Damage Sprites, clickering every 6th frame FOR 3 FRAMES
 if(inv&gt;0&amp;&amp;inv%6&lt;3){
     if(image_alpha&lt;1)
-    image_alpha=1;
-    else image_alpha=.2;
+    image_alpha=1;//100% opaque
+    else image_alpha=.2;//20% opaque
     if(inv-1&lt;1)image_alpha=1;//make sure the sprite is not stuck at .3/1 opacity
 }
 //removes invincibility frames until none exist


### PR DESCRIPTION
HOW TO USE
=========
Same as before really, just use 
`obj_player.hp-=NUMBER`

Overview
======
• Added knockback when damaged
 - Knockback is based on current facing direction
  - Created a variable to store the last direction
• Fixed some possible issues, replacing poor check handling
• Fixed some issues with damage flickering
• Added a template for enemy checking
 - The template is mostly a placeholder and an example on how to treat damage frames
 >> Enemies do not exist, therefore the template is commented as a TODO